### PR TITLE
Changed Ekubo URL from landing page directly to the dApp

### DIFF
--- a/repository/ekubo/metadata.json
+++ b/repository/ekubo/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "ekubo",
   "displayName": "Ekubo",
-  "host": "ekubo.org",
+  "host": "app.ekubo.org",
   "description": "The most powerful AMM on Starknet, featuring super-concentrated liquidity and extensibility.",
   "categories": [
     "defi"


### PR DESCRIPTION
Right now the Ekubo link in the Braavos mobile wallet on android device opens a landing page `ekubo.org`, and after clicking "Launch app" the system browser is opened instead.
This makes it impossible to open Ekubo dapp from the shortcut.
The only way to open Ekubo dapp is to enter the URL manually into the search input.

This PR changes the Ekubo URL from `ekubo.org` to `app.ekubo.org`, which in turn should fix the problem in the mobile wallet on Android devices.